### PR TITLE
fixes #63 Add check for null context

### DIFF
--- a/src/main/java/brave/opentracing/BraveSpanBuilder.java
+++ b/src/main/java/brave/opentracing/BraveSpanBuilder.java
@@ -65,7 +65,7 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
   }
 
   @Override public BraveSpanBuilder addReference(String type, SpanContext context) {
-    if (parent != null) {
+    if (parent != null || context == null) {
       return this;
     }
     if (References.CHILD_OF.equals(type) || References.FOLLOWS_FROM.equals(type)) {


### PR DESCRIPTION
Check for null context, since per OpenTracing javadoc that's supposed to be a noop rather than NPE.