### PR TITLE
Handles incomplete extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <main.java.version>1.7</main.java.version>
     <main.signature.artifact>java17</main.signature.artifact>
 
-    <brave.version>4.13.3</brave.version>
+    <brave.version>4.14.1</brave.version>
 
     <!-- default bytecode version for src/test -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/brave/opentracing/BraveSpan.java
+++ b/src/main/java/brave/opentracing/BraveSpan.java
@@ -48,7 +48,7 @@ public final class BraveSpan implements Span {
   }
 
   @Override public BraveSpanContext context() {
-    return BraveSpanContext.wrap(delegate.context());
+    return BraveSpanContext.create(delegate.context());
   }
 
   @Override public BraveSpan setTag(String key, String value) {

--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -21,7 +21,6 @@ import brave.propagation.TraceContext.Injector;
 import brave.propagation.TraceContextOrSamplingFlags;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
-import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
@@ -180,8 +179,8 @@ public final class BraveTracer implements Tracer {
     if (extractor == null) {
       throw new UnsupportedOperationException(format + " not in " + formatToExtractor.keySet());
     }
-    TraceContextOrSamplingFlags result = extractor.extract((TextMap) carrier);
-    return result.context() != null ? BraveSpanContext.wrap(result.context()) : null;
+    TraceContextOrSamplingFlags extractionResult = extractor.extract((TextMap) carrier);
+    return BraveSpanContext.create(extractionResult);
   }
 
   /**

--- a/src/test/java/brave/opentracing/BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/BraveTracerTest.java
@@ -148,14 +148,14 @@ public class BraveTracerTest {
             .sampled(true).build());
   }
 
-  @Test public void extractTraceContextReturnsNull() throws Exception {
+  @Test public void extractTraceContext_unwrapReturnsNull() throws Exception {
     Map<String, String> map = new LinkedHashMap<>();
     map.put("other", "1");
 
     BraveSpanContext openTracingContext = opentracing.extract(Format.Builtin.HTTP_HEADERS,
             new TextMapExtractAdapter(map));
 
-    assertThat(openTracingContext).isNull();
+    assertThat(openTracingContext.unwrap()).isNull();
   }
 
   @Test public void injectTraceContext() throws Exception {
@@ -166,7 +166,7 @@ public class BraveTracerTest {
 
     Map<String, String> map = new LinkedHashMap<>();
     TextMapInjectAdapter carrier = new TextMapInjectAdapter(map);
-    opentracing.inject(BraveSpanContext.wrap(context), Format.Builtin.HTTP_HEADERS, carrier);
+    opentracing.inject(BraveSpanContext.create(context), Format.Builtin.HTTP_HEADERS, carrier);
 
     assertThat(map).containsExactly(
         entry("X-B3-TraceId", "0000000000000001"),
@@ -194,7 +194,7 @@ public class BraveTracerTest {
 
     Map<String, String> map = new LinkedHashMap<>();
     TextMapInjectAdapter carrier = new TextMapInjectAdapter(map);
-    opentracing.inject(BraveSpanContext.wrap(context), Format.Builtin.TEXT_MAP, carrier);
+    opentracing.inject(BraveSpanContext.create(context), Format.Builtin.TEXT_MAP, carrier);
 
     assertThat(map).containsExactly(
         entry("X-B3-TraceId", "0000000000000001"),
@@ -216,7 +216,7 @@ public class BraveTracerTest {
 
     Map<String, String> map = new LinkedHashMap<>();
     TextMapInjectAdapter carrier = new TextMapInjectAdapter(map);
-    opentracing.inject(BraveSpanContext.wrap(context), B3, carrier);
+    opentracing.inject(BraveSpanContext.create(context), B3, carrier);
 
     assertThat(map).containsExactly(
         entry("X-B3-TraceId", "0000000000000001"),


### PR DESCRIPTION
OpenTracing uses the same type SpanContext to catch an extraction from
headers result as it does to represent an in-flight span. Extraction can
be incomplete, for example only including sampling state, or in the case
of jaeger a debug ID.

There's no OpenTracing semantics for this, so using Jaeger's approach
which is to hide details in the SpanContext and assume folks don't
always expect a SpanContext to represent a span.

See https://github.com/jaegertracing/jaeger-client-java/blame/7f01beeaa86c853c9fe796bf9f6fb30bbaf3131d/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java#L380
Fixes #67