### PR TITLE
Support opentracing-api 0.32 and 0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <version>0.34.0-SNAPSHOT</version>
 
   <properties>
+    <main.basedir>${project.basedir}</main.basedir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
@@ -40,10 +41,17 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <errorprone.args />
+    <!-- disable errorprone override warning as this allows us to support different versions -->
+    <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
     <errorprone.version>2.3.3</errorprone.version>
 
-    <main.basedir>${project.basedir}</main.basedir>
+    <!-- versions needed also for integration tests -->
+    <junit.version>4.12</junit.version>
+    <assertj.version>3.12.2</assertj.version>
+    <mockito.version>2.28.2</mockito.version>
+    <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
   </properties>
 
   <organization>
@@ -107,7 +115,7 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>0.31.0</version>
+      <version>0.32.0</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.brave</groupId>
@@ -117,7 +125,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -128,19 +136,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.12.1</version>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.tngtech.java</groupId>
       <artifactId>junit-dataprovider</artifactId>
-      <version>1.13.1</version>
+      <version>${junit-dataprovider.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -159,7 +167,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>${maven-compiler-plugin.version}</version>
         <inherited>true</inherited>
         <configuration>
           <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
@@ -169,6 +177,11 @@
           <fork>true</fork>
           <showWarnings>true</showWarnings>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
       </plugin>
 
       <plugin>
@@ -282,11 +295,6 @@
           <repo>maven</repo>
           <packageName>opentracing-brave</packageName>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
       </plugin>
 
       <plugin>

--- a/src/it/opentracing-0.31/src/test/java/brave/opentracing/OpenTracing0_31_UnsupportedTest.java
+++ b/src/it/opentracing-0.31/src/test/java/brave/opentracing/OpenTracing0_31_UnsupportedTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import brave.Tracing;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class OpenTracing0_31_UnsupportedTest {
+  @Test public void unsupported() {
+    try (Tracing brave = Tracing.newBuilder().build()) {
+      BraveTracer.create(brave);
+
+      failBecauseExceptionWasNotThrown(ExceptionInInitializerError.class);
+    } catch (UnsupportedOperationException e) {
+      assertThat(e.getMessage()).startsWith("OpenTracing 0.31 detected.");
+    }
+  }
+}

--- a/src/it/opentracing-0.33/README.md
+++ b/src/it/opentracing-0.33/README.md
@@ -1,0 +1,2 @@
+# OpenTracing 0.31
+This tests that BraveTracer can be used with OpenTracing 0.31

--- a/src/it/opentracing-0.33/pom.xml
+++ b/src/it/opentracing-0.33/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>opentracing-0.33</artifactId>
+  <version>@project.version@</version>
+  <name>opentracing-0.33</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>brave-opentracing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>0.33.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>@junit.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>@mockito.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.java</groupId>
+      <artifactId>junit-dataprovider</artifactId>
+      <version>@junit-dataprovider.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-tests</artifactId>
+      <version>@brave.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- treat the real projects test tree as our main tree, allowing us to extend test classes -->
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <includes>
+            <include>**/OpenTracing0_33_*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-surefire-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/Brave*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveScopeManagerTest.java
+++ b/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveScopeManagerTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+public class BraveScopeManagerTest extends OpenTracing0_33_BraveScopeManagerTest {
+}

--- a/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveSpanBuilderTest.java
+++ b/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveSpanBuilderTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+public class BraveSpanBuilderTest extends OpenTracing0_33_BraveSpanBuilderTest {
+}

--- a/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveSpanTest.java
+++ b/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveSpanTest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+public class BraveSpanTest extends OpenTracing0_33_BraveSpanTest {
+}

--- a/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveTracerTest.java
+++ b/src/it/opentracing-0.33/src/test/java/brave/opentracing/BraveTracerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BraveTracerTest extends OpenTracing0_33_BraveTracerTest {
+  @Test public void versionIsCorrect() {
+    assertThat(OpenTracingVersion.get())
+        .isInstanceOf(OpenTracingVersion.v0_33.class);
+  }
+}

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/src/main/java/brave/opentracing/BraveScope.java
+++ b/src/main/java/brave/opentracing/BraveScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -50,7 +50,8 @@ public final class BraveScope implements Scope {
     source.deregister(this);
   }
 
-  @Override public BraveSpan span() {
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated public BraveSpan span() {
     return wrapped;
   }
 

--- a/src/main/java/brave/opentracing/BraveScopeManager.java
+++ b/src/main/java/brave/opentracing/BraveScopeManager.java
@@ -14,101 +14,46 @@
 package brave.opentracing;
 
 import brave.Tracer;
-import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 /** This integrates with Brave's {@link CurrentTraceContext}. */
-public final class BraveScopeManager implements ScopeManager {
-  // This probably needs to be redesigned to stash the OpenTracing span in brave's .extra()
-  // We wouldn't have to do this if it weren't a requirement to return the same instance...
-  //
-  // When scopes are leaked this thread local will prevent this type from being unloaded. This can
-  // cause problems in redeployment scenarios. https://github.com/openzipkin/brave/issues/785
-  final ThreadLocal<Deque<BraveScope>> currentScopes = new ThreadLocal<Deque<BraveScope>>() {
-    @Override protected Deque<BraveScope> initialValue() {
-      return new ArrayDeque<>();
-    }
-  };
-  private final Tracer tracer;
+public class BraveScopeManager implements ScopeManager {
+  final brave.Tracer tracer;
 
-  BraveScopeManager(Tracing tracing) {
-    tracer = tracing.tracer();
-  }
-
-  /**
-   * This api's only purpose is to retrieve the {@link BraveScope#span() span}.
-   *
-   * Calling {@link Scope#close() close } on the returned scope has no effect on the active span
-   */
-  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-  @Deprecated public Scope active() {
-    BraveSpan span = currentSpan();
-    if (span == null) return null;
-    return new Scope() {
-      @Override public void close() {
-        // no-op
-      }
-
-      /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-      @Deprecated public Span span() {
-        return span;
-      }
-    };
-  }
-
-  @Override public BraveSpan activeSpan() {
-    brave.Span braveSpan = tracer.currentSpan();
-    if (braveSpan != null) {
-      return new BraveSpan(tracer, braveSpan);
-    }
-    return null;
-  }
-
-  /** Attempts to get a span from the current api, falling back to brave's native one */
-  @Deprecated BraveSpan currentSpan() {
-    BraveScope scope = currentScopes.get().peekFirst();
-    if (scope != null) {
-      return scope.span();
-    } else {
-      brave.Span braveSpan = tracer.currentSpan();
-      if (braveSpan != null) {
-        return new BraveSpan(tracer, braveSpan);
-      }
-    }
-    return null;
+  BraveScopeManager(Tracer tracer) {
+    this.tracer = tracer;
   }
 
   @Override public BraveScope activate(Span span) {
-    return activate(span, false);
-  }
-
-  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-  @Deprecated public BraveScope activate(Span span, boolean finishSpanOnClose) {
     if (span == null) return null;
     if (!(span instanceof BraveSpan)) {
       throw new IllegalArgumentException(
           "Span must be an instance of brave.opentracing.BraveSpan, but was " + span.getClass());
     }
-    return newScope((BraveSpan) span, finishSpanOnClose);
+    return new BraveScope(tracer.withSpanInScope(((BraveSpan) span).delegate));
   }
 
-  BraveScope newScope(BraveSpan span, boolean finishSpanOnClose) {
-    BraveScope result = new BraveScope(
-        this,
-        tracer.withSpanInScope(span.delegate),
-        span,
-        finishSpanOnClose
-    );
-    currentScopes.get().addFirst(result);
-    return result;
+  @Override public BraveSpan activeSpan() {
+    brave.Span braveSpan = tracer.currentSpan();
+    return braveSpan != null ? new BraveSpan(tracer, braveSpan) : null;
   }
 
-  void deregister(BraveScope span) {
-    currentScopes.get().remove(span);
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated public Scope active() {
+    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
+  }
+
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated public BraveScope activate(Span span, boolean finishSpanOnClose) {
+    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
+  }
+
+  /** Attempts to get a span from the current api, falling back to brave's native one */
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated BraveSpan currentSpan() {
+    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
   }
 }

--- a/src/main/java/brave/opentracing/BraveSpan.java
+++ b/src/main/java/brave/opentracing/BraveSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -91,6 +91,14 @@ public final class BraveSpan implements Span {
       delegate = tracer.toSpan(delegate.context().toBuilder().sampled(false).build());
     }
     return setTag(key, value.toString());
+  }
+
+  @Override public <T> BraveSpan setTag(io.opentracing.tag.Tag<T> tag, T value) {
+    // Strange there's a new api only to dispatch something that can be done as easily directly
+    // eg instead of tag.set(span, value) this allows span.setTag(tag, value) (3 more characters!)
+    // Would be nice to see documentation clarify why this was important enough to break api over.
+    tag.set(this, value);
+    return this;
   }
 
   @Override public BraveSpan log(Map<String, ?> fields) {

--- a/src/main/java/brave/opentracing/BraveSpanBuilder.java
+++ b/src/main/java/brave/opentracing/BraveSpanBuilder.java
@@ -16,7 +16,6 @@ package brave.opentracing;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import io.opentracing.References;
-import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -34,21 +33,18 @@ import java.util.Map;
  * <p>Brave does not support multiple parents so this has been implemented to use the first parent
  * defined.
  */
-public final class BraveSpanBuilder implements Tracer.SpanBuilder {
+public class BraveSpanBuilder implements Tracer.SpanBuilder {
+  final brave.Tracer tracer;
+  final Map<String, String> tags = new LinkedHashMap<>();
 
-  private final BraveTracer tracer;
-  private final brave.Tracer braveTracer;
-  private final Map<String, String> tags = new LinkedHashMap<>();
+  String operationName;
+  long timestamp;
+  int remotePort;
+  BraveSpanContext reference;
+  boolean ignoreActiveSpan = false;
 
-  private String operationName;
-  private long timestamp;
-  private int remotePort;
-  private BraveSpanContext reference;
-  private boolean ignoreActiveSpan = false;
-
-  BraveSpanBuilder(BraveTracer tracer, brave.Tracer braveTracer, String operationName) {
+  BraveSpanBuilder(brave.Tracer tracer, String operationName) {
     this.tracer = tracer;
-    this.braveTracer = braveTracer;
     this.operationName = operationName;
   }
 
@@ -61,9 +57,7 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
   }
 
   @Override public BraveSpanBuilder addReference(String type, SpanContext context) {
-    if (reference != null || context == null) {
-      return this;
-    }
+    if (reference != null || context == null) return this;
     if (References.CHILD_OF.equals(type) || References.FOLLOWS_FROM.equals(type)) {
       this.reference = (BraveSpanContext) context;
     }
@@ -102,22 +96,6 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
     return this;
   }
 
-  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-  @Deprecated public BraveSpan startManual() {
-    return start();
-  }
-
-  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-  @Deprecated public BraveScope startActive(boolean finishSpanOnClose) {
-    if (!ignoreActiveSpan) {
-      BraveSpan parent = tracer.scopeManager().activeSpan();
-      if (parent != null) {
-        asChildOf(parent.context());
-      }
-    }
-    return tracer.scopeManager().activate(start(), finishSpanOnClose);
-  }
-
   @Override public BraveSpanBuilder ignoreActiveSpan() {
     ignoreActiveSpan = true;
     return this;
@@ -128,10 +106,8 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
 
     // Check if active span should be established as CHILD_OF relationship
     if (reference == null && !ignoreActiveSpan) {
-      BraveSpan parent = tracer.scopeManager().activeSpan();
-      if (parent != null) {
-        asChildOf(parent.context());
-      }
+      brave.Span parent = tracer.currentSpan();
+      if (parent != null) asChildOf(BraveSpanContext.create(parent.context()));
     }
 
     brave.Span span;
@@ -139,32 +115,32 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
     if (reference == null) {
       // adjust sampling decision, this reflects Zipkin's "before the fact" sampling policy
       // https://github.com/openzipkin/brave/tree/master/brave#sampling
-      brave.Tracer scopedBraveTracer = braveTracer;
+      brave.Tracer scopedTracer = tracer;
       String sampling = tags.get(Tags.SAMPLING_PRIORITY.getKey());
       if (sampling != null) {
         try {
           Integer samplingPriority = Integer.valueOf(sampling);
           if (samplingPriority == 0) {
-            scopedBraveTracer = braveTracer.withSampler(Sampler.NEVER_SAMPLE);
+            scopedTracer = tracer.withSampler(Sampler.NEVER_SAMPLE);
           } else if (samplingPriority > 0) {
-            scopedBraveTracer = braveTracer.withSampler(Sampler.ALWAYS_SAMPLE);
+            scopedTracer = tracer.withSampler(Sampler.ALWAYS_SAMPLE);
           }
         } catch (NumberFormatException ex) {
           // ignore
         }
       }
-      span = scopedBraveTracer.newTrace();
+      span = scopedTracer.newTrace();
     } else if ((context = reference.unwrap()) != null) {
       // Zipkin's default is to share a span ID between the client and the server in an RPC.
       // When we start a server span with a parent, we assume the "parent" is actually the
       // client on the other side of the RPC. Accordingly, we join that span instead of fork.
-      span = server ? braveTracer.joinSpan(context) : braveTracer.newChild(context);
+      span = server ? tracer.joinSpan(context) : tracer.newChild(context);
     } else {
-      span = braveTracer.nextSpan(((BraveSpanContext.Incomplete) reference).extractionResult());
+      span = tracer.nextSpan(((BraveSpanContext.Incomplete) reference).extractionResult());
     }
 
     if (operationName != null) span.name(operationName);
-    BraveSpan result = new BraveSpan(braveTracer, span);
+    BraveSpan result = new BraveSpan(tracer, span);
     result.remotePort = remotePort;
     for (Map.Entry<String, String> tag : tags.entrySet()) {
       result.setTag(tag.getKey(), tag.getValue());
@@ -177,5 +153,15 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
     }
 
     return result;
+  }
+
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated public BraveSpan startManual() {
+    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
+  }
+
+  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+  @Deprecated public BraveScope startActive(boolean finishSpanOnClose) {
+    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
   }
 }

--- a/src/main/java/brave/opentracing/BraveSpanBuilder.java
+++ b/src/main/java/brave/opentracing/BraveSpanBuilder.java
@@ -19,6 +19,7 @@ import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.tag.Tag;
 import io.opentracing.tag.Tags;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -82,13 +83,13 @@ public class BraveSpanBuilder implements Tracer.SpanBuilder {
     return withTag(key, value.toString());
   }
 
-  @Override public <T> BraveSpanBuilder withTag(io.opentracing.tag.Tag<T> tag, T value) {
+  @Override public <T> BraveSpanBuilder withTag(Tag<T> tag, T value) {
     if (tag == null) throw new NullPointerException("tag == null");
     if (value == null) throw new NullPointerException("value == null");
     if (value instanceof String) return withTag(tag.getKey(), (String) value);
     if (value instanceof Number) return withTag(tag.getKey(), (Number) value);
     if (value instanceof Boolean) return withTag(tag.getKey(), (Boolean) value);
-    throw new IllegalArgumentException("tag value not a string, number or boolean: " + tag);
+    throw new IllegalArgumentException("tag value not a string, number or boolean: " + value);
   }
 
   @Override public BraveSpanBuilder withStartTimestamp(long microseconds) {

--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -148,6 +148,7 @@ public final class BraveTracer implements Tracer {
       formatToExtractor.put(entry.getKey(), new TextMapExtractorAdaptor(entry.getValue()));
     }
 
+    // Now, go back and make sure the special inject/extract forms work
     for (Propagation<String> propagation : b.formatToPropagation.values()) {
       formatToInjector.put(TEXT_MAP_INJECT, propagation.injector(TEXT_MAP_SETTER));
       formatToExtractor.put(TEXT_MAP_EXTRACT, new TextMapExtractorAdaptor(propagation));

--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -79,6 +79,16 @@ public final class BraveTracer implements Tracer {
    * ScopeManager}.
    */
   public static Builder newBuilder(Tracing brave4) {
+    // This is the only public entrypoint into the brave-opentracing bridge. The following will
+    // raise an exception when using an incompatible version of opentracing-api. Notably, this
+    // unwraps ExceptionInInitializerError to avoid confusing users, as this is an implementation
+    // detail of the version singleton.
+    try {
+      OpenTracingVersion.get();
+    } catch (ExceptionInInitializerError e) {
+      if (e.getCause() instanceof RuntimeException) throw (RuntimeException) e.getCause();
+      throw e;
+    }
     return new Builder(brave4);
   }
 

--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -36,7 +36,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import javafx.application.Platform;
+
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP_EXTRACT;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP_INJECT;
 
 /**
  * Using a tracer, you can create a spans, inject span contexts into a transport, and extract span
@@ -103,7 +105,6 @@ public final class BraveTracer implements Tracer {
 
       formatToPropagation.put(Format.Builtin.HTTP_HEADERS, tracing.propagation());
       formatToPropagation.put(Format.Builtin.TEXT_MAP, tracing.propagation());
-      // TODO: TEXT_MAP_INJECT and TEXT_MAP_EXTRACT (not excited about this)
     }
 
     /**
@@ -148,9 +149,8 @@ public final class BraveTracer implements Tracer {
     }
 
     for (Propagation<String> propagation : b.formatToPropagation.values()) {
-      formatToInjector.put(Format.Builtin.TEXT_MAP_INJECT, propagation.injector(TEXT_MAP_SETTER));
-      formatToExtractor.put(Format.Builtin.TEXT_MAP_EXTRACT,
-          new TextMapExtractorAdaptor(propagation));
+      formatToInjector.put(TEXT_MAP_INJECT, propagation.injector(TEXT_MAP_SETTER));
+      formatToExtractor.put(TEXT_MAP_EXTRACT, new TextMapExtractorAdaptor(propagation));
     }
   }
 

--- a/src/main/java/brave/opentracing/OpenTracingVersion.java
+++ b/src/main/java/brave/opentracing/OpenTracingVersion.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+/**
+ * Access to version-specific features.
+ *
+ * <p>Originally designed by OkHttp team, derived from {@code okhttp3.internal.platform.OpenTracingVersion}
+ */
+abstract class OpenTracingVersion {
+  private static final OpenTracingVersion INSTANCE = findVersion();
+
+  static OpenTracingVersion get() {
+    return INSTANCE;
+  }
+
+  /** Attempt to match the host runtime to a capable OpenTracingVersion implementation. */
+  static OpenTracingVersion findVersion() {
+    OpenTracingVersion version = v0_32.buildIfSupported();
+    if (version != null) return version;
+
+    version = v0_33.buildIfSupported();
+    if (version != null) return version;
+
+    throw new UnsupportedOperationException("Unsupported opentracing-api version");
+  }
+
+  static class v0_33 extends OpenTracingVersion {
+    static v0_33 buildIfSupported() {
+      // Find OpenTracing 0.32 new type
+      try {
+        Class.forName("io.opentracing.tag.Tag");
+        return new v0_33();
+      } catch (ClassNotFoundException e) {
+      }
+      return null;
+    }
+
+    @Override public String toString() {
+      return "v0_33{}";
+    }
+
+    v0_33() {
+    }
+  }
+
+  static class v0_32 extends OpenTracingVersion {
+    static v0_32 buildIfSupported() {
+      // Find OpenTracing 0.32 deprecated method
+      try {
+        if (ScopeManager.class.getMethod("activate", Span.class, boolean.class)
+            .getAnnotation(Deprecated.class) != null) {
+          return new v0_32();
+        }
+      } catch (NoSuchMethodException e) {
+      }
+      return null;
+    }
+
+    @Override public String toString() {
+      return "v0_32{}";
+    }
+
+    v0_32() {
+    }
+  }
+}

--- a/src/main/java/brave/opentracing/OpenTracingVersion.java
+++ b/src/main/java/brave/opentracing/OpenTracingVersion.java
@@ -42,7 +42,7 @@ abstract class OpenTracingVersion {
     if (isV0_31()) {
       throw new UnsupportedOperationException("OpenTracing 0.31 detected. "
           + "This version is compatible with io.opentracing:opentracing-api 0.32 or 0.33. "
-          + "Use latest io.opentracing.brave:brave-opentracing:0.33 or update you opentracing-api");
+          + "io.opentracing.brave:brave-opentracing:0.33.13+ works with version 0.31");
     }
 
     OpenTracingVersion version = v0_32.buildIfSupported();

--- a/src/main/java/brave/opentracing/OpenTracingVersion.java
+++ b/src/main/java/brave/opentracing/OpenTracingVersion.java
@@ -39,13 +39,32 @@ abstract class OpenTracingVersion {
 
   /** Attempt to match the host runtime to a capable OpenTracingVersion implementation. */
   private static OpenTracingVersion findVersion() {
+    if (isV0_31()) {
+      throw new UnsupportedOperationException("OpenTracing 0.31 detected. "
+          + "This version is compatible with io.opentracing:opentracing-api 0.32 or 0.33. "
+          + "Use latest io.opentracing.brave:brave-opentracing:0.33 or update you opentracing-api");
+    }
+
     OpenTracingVersion version = v0_32.buildIfSupported();
     if (version != null) return version;
 
     version = v0_33.buildIfSupported();
     if (version != null) return version;
 
-    throw new UnsupportedOperationException("Unsupported opentracing-api version");
+    throw new UnsupportedOperationException(
+        "This is only compatible with io.opentracing:opentracing-api 0.32 or 0.33");
+  }
+
+  static boolean isV0_31() {
+    // Find OpenTracing 0.31 method
+    try {
+      if (ScopeManager.class.getMethod("activate", Span.class, boolean.class)
+          .getAnnotation(Deprecated.class) == null) {
+        return true;
+      }
+    } catch (NoSuchMethodException e) {
+    }
+    return false;
   }
 
   static class v0_32 extends OpenTracingVersion {

--- a/src/main/java/brave/opentracing/v0_32_BraveScope.java
+++ b/src/main/java/brave/opentracing/v0_32_BraveScope.java
@@ -14,34 +14,36 @@
 package brave.opentracing;
 
 import brave.Tracer.SpanInScope;
-import io.opentracing.Scope;
 
-/**
- * {@link BraveScope} is a simple {@link Scope} implementation that wraps the corresponding {@link
- * SpanInScope Brave scope}.
- *
- * @see SpanInScope
- */
-public class BraveScope implements Scope {
-  final SpanInScope delegate;
+final class v0_32_BraveScope extends BraveScope {
+  final v0_32_BraveScopeManager source;
+  final BraveSpan wrapped;
+  final boolean finishSpanOnClose;
 
   /**
    * @param delegate a SpanInScope to be closed upon deactivation of this ActiveSpan
+   * @param source the BraveActiveSpanSource that created this BraveActiveSpan
+   * @param wrapped the wrapped BraveSpan to which we will delegate all span operations
    */
-  BraveScope(SpanInScope delegate) {
-    this.delegate = delegate;
+  v0_32_BraveScope(SpanInScope delegate, v0_32_BraveScopeManager source, BraveSpan wrapped,
+      boolean finishSpanOnClose) {
+    super(delegate);
+    this.source = source;
+    this.wrapped = wrapped;
+    this.finishSpanOnClose = finishSpanOnClose;
   }
 
   @Override public void close() {
-    delegate.close();
+    super.close();
+    if (finishSpanOnClose) wrapped.finish();
+    source.deregister(this);
   }
 
-  /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
-  @Deprecated public BraveSpan span() {
-    throw new UnsupportedOperationException("Not supported in OpenTracing 0.33+");
+  @Override @Deprecated public BraveSpan span() {
+    return wrapped;
   }
 
   @Override public String toString() {
-    return "BraveScope(" + delegate + ")";
+    return "BraveScope{scope=" + delegate + ", wrapped=" + wrapped.delegate + '}';
   }
 }

--- a/src/main/java/brave/opentracing/v0_32_BraveScopeManager.java
+++ b/src/main/java/brave/opentracing/v0_32_BraveScopeManager.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import brave.Tracer;
+import brave.propagation.CurrentTraceContext;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/** This integrates with Brave's {@link CurrentTraceContext}. */
+final class v0_32_BraveScopeManager extends BraveScopeManager {
+  // This probably needs to be redesigned to stash the OpenTracing span in brave's .extra()
+  // We wouldn't have to do this if it weren't a requirement to return the same instance...
+  //
+  // When scopes are leaked this thread local will prevent this type from being unloaded. This can
+  // cause problems in redeployment scenarios. https://github.com/openzipkin/brave/issues/785
+  final ThreadLocal<Deque<v0_32_BraveScope>> currentScopes =
+      new ThreadLocal<Deque<v0_32_BraveScope>>() {
+        @Override protected Deque<v0_32_BraveScope> initialValue() {
+          return new ArrayDeque<>();
+        }
+      };
+
+  v0_32_BraveScopeManager(Tracer tracer) {
+    super(tracer);
+  }
+
+  @Override @Deprecated public Scope active() {
+    BraveSpan span = currentSpan();
+    if (span == null) return null;
+    return new Scope() {
+      @Override public void close() {
+        // no-op
+      }
+
+      /* @Override deprecated 0.32 method: Intentionally no override to ensure 0.33 works! */
+      @Deprecated public Span span() {
+        return span;
+      }
+    };
+  }
+
+  @Override @Deprecated BraveSpan currentSpan() {
+    BraveScope scope = currentScopes.get().peekFirst();
+    if (scope != null) {
+      return scope.span();
+    } else {
+      brave.Span braveSpan = tracer.currentSpan();
+      if (braveSpan != null) {
+        return new BraveSpan(tracer, braveSpan);
+      }
+    }
+    return null;
+  }
+
+  @Override public BraveScope activate(Span span) {
+    return activate(span, false);
+  }
+
+  @Override @Deprecated public BraveScope activate(Span span, boolean finishSpanOnClose) {
+    if (span == null) return null;
+    if (!(span instanceof BraveSpan)) {
+      throw new IllegalArgumentException(
+          "Span must be an instance of brave.opentracing.BraveSpan, but was " + span.getClass());
+    }
+    return newScope((BraveSpan) span, finishSpanOnClose);
+  }
+
+  BraveScope newScope(BraveSpan span, boolean finishSpanOnClose) {
+    v0_32_BraveScope result = new v0_32_BraveScope(
+        tracer.withSpanInScope(span.delegate), this, span, finishSpanOnClose
+    );
+    currentScopes.get().addFirst(result);
+    return result;
+  }
+
+  void deregister(BraveScope span) {
+    currentScopes.get().remove(span);
+  }
+}

--- a/src/main/java/brave/opentracing/v0_32_BraveSpanBuilder.java
+++ b/src/main/java/brave/opentracing/v0_32_BraveSpanBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+final class v0_32_BraveSpanBuilder extends BraveSpanBuilder {
+  final BraveScopeManager scopeManager;
+
+  v0_32_BraveSpanBuilder(BraveScopeManager scopeManager, String operationName) {
+    super(scopeManager.tracer, operationName);
+    this.scopeManager = scopeManager;
+  }
+
+  @Override @Deprecated public BraveSpan startManual() {
+    return start();
+  }
+
+  @Override @Deprecated public BraveScope startActive(boolean finishSpanOnClose) {
+    if (!ignoreActiveSpan) {
+      BraveSpan parent = scopeManager.activeSpan();
+      if (parent != null) asChildOf(parent.context());
+    }
+    return scopeManager.activate(start(), finishSpanOnClose);
+  }
+}

--- a/src/test/java/brave/opentracing/OpenTracing0_32_BraveScopeManagerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_32_BraveScopeManagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import brave.ScopedSpan;
+import brave.Tracing;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import io.opentracing.Scope;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenTracing0_32_BraveScopeManagerTest {
+  List<zipkin2.Span> spans = new ArrayList<>();
+  Tracing brave = Tracing.newBuilder()
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
+      .spanReporter(spans::add)
+      .build();
+
+  BraveTracer opentracing = BraveTracer.create(brave);
+
+  @After public void clear() {
+    brave.close();
+  }
+
+  @Test public void scopeManagerActive() {
+    BraveSpan span = opentracing.buildSpan("spanA").start();
+
+    try (Scope scopeA = opentracing.scopeManager().activate(span, false)) {
+      assertThat(opentracing.scopeManager().active().span())
+          .isEqualTo(span);
+      //Call again to ensure the ThreadLocal cache works
+      assertThat(opentracing.scopeManager().active().span())
+          .isEqualTo(span);
+    }
+
+    assertThat(opentracing.scopeManager().active())
+        .isNull();
+  }
+
+  /** This ensures downstream code using OpenTracing api can see Brave's scope */
+  @Test public void scopeManagerActive_bridgesNormalBrave() {
+    ScopedSpan spanInScope = brave.tracer().startScopedSpan("spanA");
+    try {
+      assertThat(opentracing.scopeManager().active().span())
+          .extracting("delegate.context")
+          .containsExactly(spanInScope.context());
+    } finally {
+      spanInScope.finish();
+    }
+  }
+
+  @Test public void scopeManagerNested() {
+    BraveSpan spanA = opentracing.buildSpan("spanA").start();
+    BraveSpan spanB = opentracing.buildSpan("spanB").start();
+
+    try (Scope scopeA = opentracing.scopeManager().activate(spanA, false)) {
+      try (Scope scopeB = opentracing.scopeManager().activate(spanB, false)) {
+        assertThat(opentracing.scopeManager().active().span())
+            .isEqualTo(spanB);
+      }
+
+      assertThat(opentracing.scopeManager().active().span())
+          .isEqualTo(spanA);
+    }
+  }
+
+  @Test public void scopeManagerActiveClose() {
+    BraveSpan spanA = opentracing.buildSpan("spanA").start();
+    try (Scope scopeA = opentracing.scopeManager().activate(spanA, false)) {
+      Scope scopeB = opentracing.scopeManager().active();
+
+      scopeB.close();
+    }
+  }
+}

--- a/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import brave.Tracing;
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.StrictScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import io.opentracing.Scope;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class OpenTracing0_32_BraveTracerTest {
+  List<zipkin2.Span> spans = new ArrayList<>();
+  Tracing brave = Tracing.newBuilder()
+      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+          .addScopeDecorator(StrictScopeDecorator.create())
+          .build())
+      .propagationFactory(ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
+          .addPrefixedFields("baggage-", Arrays.asList("country-code", "user-id"))
+          .build())
+      .spanReporter(spans::add)
+      .build();
+  BraveTracer opentracing = BraveTracer.create(brave);
+
+  @After public void clear() {
+    brave.close();
+  }
+
+  @Test public void versionIsCorrect() {
+    assertThat(OpenTracingVersion.get())
+        .isInstanceOf(OpenTracingVersion.v0_32.class);
+  }
+
+  /** OpenTracing span implements auto-closeable, and implies reporting on close */
+  @Test public void startActive_autoCloseOnTryFinally() {
+    try (Scope scope = opentracing.buildSpan("foo").startActive(true)) {
+    }
+
+    assertThat(spans)
+        .hasSize(1);
+  }
+
+  @Test public void startActive_autoCloseOnTryFinally_doesntReportTwice() {
+    try (Scope scope = opentracing.buildSpan("foo").startActive(true)) {
+      opentracing.activeSpan().finish(); // user closes and also auto-close closes
+    }
+
+    assertThat(spans)
+        .hasSize(1);
+  }
+
+  @Test public void startActive_autoCloseOnTryFinally_dontClose() {
+    try (Scope scope = opentracing.buildSpan("foo").startActive(false)) {
+    }
+
+    assertThat(spans)
+        .isEmpty();
+  }
+
+  @Test public void subsequentChildrenNestProperly_OTStyle() {
+    // this test is semantically identical to subsequentChildrenNestProperly_BraveStyle, but uses
+    // the OpenTracingAPI instead of the Brave API.
+
+    Long idOfSpanA;
+    Long shouldBeIdOfSpanA;
+    Long idOfSpanB;
+    Long shouldBeIdOfSpanB;
+    Long parentIdOfSpanB;
+    Long parentIdOfSpanC;
+
+    try (Scope scopeA = opentracing.buildSpan("spanA").startActive(false)) {
+      idOfSpanA = brave.currentTraceContext().get().spanId();
+      try (Scope scopeB = opentracing.buildSpan("spanB").startActive(false)) {
+        idOfSpanB = brave.currentTraceContext().get().spanId();
+        parentIdOfSpanB = brave.currentTraceContext().get().parentId();
+        shouldBeIdOfSpanB = brave.currentTraceContext().get().spanId();
+      }
+      shouldBeIdOfSpanA = brave.currentTraceContext().get().spanId();
+      try (Scope scopeC = opentracing.buildSpan("spanC").startActive(false)) {
+        parentIdOfSpanC = brave.currentTraceContext().get().parentId();
+      }
+    }
+
+    assertEquals("SpanA should have been active again after closing B", idOfSpanA,
+        shouldBeIdOfSpanA);
+    assertEquals("SpanB should have been active prior to its closure", idOfSpanB,
+        shouldBeIdOfSpanB);
+    assertEquals("SpanB's parent should be SpanA", idOfSpanA, parentIdOfSpanB);
+    assertEquals("SpanC's parent should be SpanA", idOfSpanA, parentIdOfSpanC);
+  }
+
+  @Test public void implicitParentFromSpanManager_startActive() {
+    try (BraveScope scopeA = opentracing.buildSpan("spanA").startActive(true)) {
+      try (BraveScope scopeB = opentracing.buildSpan("spanB").startActive(true)) {
+        TraceContext current = brave.currentTraceContext().get();
+        assertThat(scopeB.span().context().unwrap().parentId())
+            .isEqualTo(scopeA.span().context().unwrap().spanId());
+      }
+    }
+  }
+
+  @Test public void implicitParentFromSpanManager_start() {
+    try (Scope scopeA = opentracing.buildSpan("spanA").startActive(true)) {
+      BraveSpan span = opentracing.buildSpan("spanB").start();
+      assertThat(span.unwrap().context().parentId())
+          .isEqualTo(brave.currentTraceContext().get().spanId());
+    }
+  }
+
+  @Test public void implicitParentFromSpanManager_startActive_ignoreActiveSpan() {
+    try (Scope scopeA = opentracing.buildSpan("spanA").startActive(true)) {
+      try (Scope scopeB = opentracing.buildSpan("spanA")
+          .ignoreActiveSpan().startActive(true)) {
+        assertThat(brave.currentTraceContext().get().parentId())
+            .isNull(); // new trace
+      }
+    }
+  }
+
+  @Test public void implicitParentFromSpanManager_start_ignoreActiveSpan() {
+    try (Scope scopeA = opentracing.buildSpan("spanA").startActive(true)) {
+      BraveSpan span = opentracing.buildSpan("spanB")
+          .ignoreActiveSpan().start();
+      assertThat(span.unwrap().context().parentId())
+          .isNull(); // new trace
+    }
+  }
+}

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class BraveSpanBuilderTest {
+public class OpenTracing0_33_BraveSpanBuilderTest {
 
   /** Ensures when the caller invokes with null, nothing happens */
   @Test public void asChildOf_nullParentContext_noop() {

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
@@ -48,6 +48,6 @@ public class OpenTracing0_33_BraveSpanBuilderTest {
 
   BraveSpanBuilder newSpanBuilder() {
     // hijacking nullability as tracer isn't referenced until build, making easier comparisons
-    return new BraveSpanBuilder(null, null, "foo");
+    return new BraveSpanBuilder(null, "foo");
   }
 }

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanTest.java
@@ -18,18 +18,21 @@ import brave.propagation.B3Propagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.sampler.Sampler;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.TextMapAdapter;
+import io.opentracing.tag.Tag;
 import io.opentracing.tag.Tags;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import zipkin2.Endpoint;
@@ -43,15 +46,24 @@ import static org.assertj.core.api.Assertions.entry;
 @RunWith(DataProviderRunner.class)
 public class OpenTracing0_33_BraveSpanTest {
   List<zipkin2.Span> spans = new ArrayList<>();
-  Tracing brave = Tracing.newBuilder()
-      .localServiceName("tracer")
-      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-          .addScopeDecorator(StrictScopeDecorator.create())
-          .build())
-      .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "client-id"))
-      .spanReporter(spans::add).build();
+  Tracing brave;
+  BraveTracer tracer;
 
-  BraveTracer tracer = BraveTracer.create(brave);
+  @Before public void init() {
+    init(Tracing.newBuilder());
+  }
+
+  void init(Tracing.Builder tracingBuilder) {
+    if (brave != null) brave.close();
+    brave = tracingBuilder
+        .localServiceName("tracer")
+        .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
+            .addScopeDecorator(StrictScopeDecorator.create())
+            .build())
+        .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "client-id"))
+        .spanReporter(spans::add).build();
+    tracer = BraveTracer.create(brave);
+  }
 
   @After public void clear() {
     brave.close();
@@ -210,6 +222,20 @@ public class OpenTracing0_33_BraveSpanTest {
     serverSpan.finish();
   }
 
+  @Test public void samplingPriority_sampledWhenAtStart() {
+    init(Tracing.newBuilder().sampler(Sampler.NEVER_SAMPLE));
+
+    BraveSpan span = tracer.buildSpan("foo")
+        .withTag(SAMPLING_PRIORITY.getKey(), 1)
+        .start();
+
+    assertThat(span.context().unwrap().sampled())
+        .isTrue();
+
+    span.finish();
+    assertThat(spans).hasSize(1);
+  }
+
   @Test public void samplingPriority_unsampledWhenAtStart() {
     BraveSpan span = tracer.buildSpan("foo")
         .withTag(SAMPLING_PRIORITY.getKey(), 0)
@@ -271,4 +297,77 @@ public class OpenTracing0_33_BraveSpanTest {
             .ip("2001:db8::c001")
             .port(8080).build());
   }
+
+  @Test public void withTag() {
+    tracer.buildSpan("encode")
+        .withTag(Tags.HTTP_METHOD.getKey(), "GET")
+        .withTag(Tags.ERROR.getKey(), true)
+        .withTag(Tags.HTTP_STATUS.getKey(), 404)
+        .start().finish();
+
+    assertContainsTags();
+  }
+
+  @Test public void withTag_object() {
+    tracer.buildSpan("encode")
+        .withTag(Tags.HTTP_METHOD, "GET")
+        .withTag(Tags.ERROR, true)
+        .withTag(Tags.HTTP_STATUS, 404)
+        .start().finish();
+
+    assertContainsTags();
+  }
+
+  @Test public void setTag() {
+    tracer.buildSpan("encode").start()
+        .setTag(Tags.HTTP_METHOD.getKey(), "GET")
+        .setTag(Tags.ERROR.getKey(), true)
+        .setTag(Tags.HTTP_STATUS.getKey(), 404)
+        .finish();
+
+    assertContainsTags();
+  }
+
+  @Test public void setTag_object() {
+    tracer.buildSpan("encode").start()
+        .setTag(Tags.HTTP_METHOD, "GET")
+        .setTag(Tags.ERROR, true)
+        .setTag(Tags.HTTP_STATUS, 404)
+        .finish();
+
+    assertContainsTags();
+  }
+
+  void assertContainsTags() {
+    assertThat(spans.get(0).tags())
+        .containsEntry("http.method", "GET")
+        .containsEntry("error", "true")
+        .containsEntry("http.status_code", "404");
+  }
+
+  Tag<Exception> exceptionTag = new Tag<Exception>() {
+    @Override public String getKey() {
+      return "exception";
+    }
+
+    @Override public void set(Span span, Exception value) {
+      span.setTag(getKey(), value.getClass().getSimpleName());
+    }
+  };
+
+  @Test public void setTag_custom() {
+    tracer.buildSpan("encode").start()
+        .setTag(exceptionTag, new RuntimeException("ice cream")).finish();
+
+    assertThat(spans.get(0).tags())
+        .containsEntry("exception", "RuntimeException");
+  }
+
+  /** There is no javadoc, but we were told only string, bool or number? */
+  @Test(expected = IllegalArgumentException.class)
+  public void withTag_custom_unsupported() {
+    tracer.buildSpan("encode")
+        .withTag(exceptionTag, new RuntimeException("ice cream"));
+  }
+
 }

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveTracerTest.java
@@ -63,6 +63,11 @@ public class OpenTracing0_33_BraveTracerTest {
     brave.close();
   }
 
+  @Test public void versionIsCorrect() {
+    assertThat(OpenTracingVersion.get())
+        .isInstanceOf(OpenTracingVersion.v0_32.class);
+  }
+
   @Test public void startWithOpenTracingAndFinishWithBrave() {
     io.opentracing.Span openTracingSpan = opentracing.buildSpan("encode")
         .withTag("lc", "codec")

--- a/src/test/java/brave/opentracing/TextMapSetterTest.java
+++ b/src/test/java/brave/opentracing/TextMapSetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,14 +16,14 @@ package brave.opentracing;
 import brave.propagation.Propagation;
 import brave.test.propagation.PropagationSetterTest;
 import io.opentracing.propagation.TextMap;
-import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.propagation.TextMapAdapter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 
 /** Verifies the method reference {@link TextMap#put} works as a Brave propagation setter */
 public class TextMapSetterTest extends PropagationSetterTest<TextMap, String> {
   LinkedHashMap<String, String> delegate = new LinkedHashMap<>();
-  TextMap carrier = new TextMapInjectAdapter(delegate);
+  TextMap carrier = new TextMapAdapter(delegate);
 
   @Override public Propagation.KeyFactory<String> keyFactory() {
     return Propagation.KeyFactory.STRING;


### PR DESCRIPTION
This updates to opentracing 0.32 and 0.33

Here are the following notes:

* 0.31 and 0.32 cannot be supported at the same time.
  * This is due to overloading of `setTag` and `withTag` with the type `Tag` which doesn't exist in 0.31. creating an unresolvable compile conflict.
* 0.32 and 0.33 are supported, with conditional code execution to avoid the flawed deprecated logic from 0.31 still present in 0.32.
* binary formats are non-baggage carrying at the moment, using b3 single the same as brave's normal JMS does.

Fixes #91