### PR TITLE
Integrates with Brave's new Baggage apis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <brave.version>5.9.2</brave.version>
+    <brave.version>5.10.3-SNAPSHOT</brave.version>
 
     <!-- default bytecode version for src/main -->
     <main.java.version>1.6</main.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <brave.version>5.10.3-SNAPSHOT</brave.version>
+    <brave.version>5.11.0</brave.version>
 
     <!-- default bytecode version for src/main -->
     <main.java.version>1.6</main.java.version>

--- a/src/test/java/brave/opentracing/OpenTracing0_32_BraveScopeManagerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_32_BraveScopeManagerTest.java
@@ -15,8 +15,7 @@ package brave.opentracing;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import io.opentracing.Scope;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OpenTracing0_32_BraveScopeManagerTest {
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder()
-      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-          .addScopeDecorator(StrictScopeDecorator.create())
-          .build())
+      .currentTraceContext(StrictCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
 

--- a/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,14 +14,13 @@
 package brave.opentracing;
 
 import brave.Tracing;
+import brave.baggage.BaggageField;
+import brave.baggage.BaggagePropagation;
 import brave.propagation.B3Propagation;
-import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.opentracing.Scope;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.After;
 import org.junit.Test;
@@ -32,12 +31,10 @@ import static org.junit.Assert.assertEquals;
 public class OpenTracing0_32_BraveTracerTest {
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder()
-      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-          .addScopeDecorator(StrictScopeDecorator.create())
-          .build())
-      .propagationFactory(ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY)
-          .addPrefixedFields("baggage-", Arrays.asList("country-code", "user-id"))
-          .build())
+      .currentTraceContext(StrictCurrentTraceContext.create())
+      .propagationFactory(BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
+          .addRemoteField(BaggageField.create("country-code"), "baggage-country-code")
+          .addRemoteField(BaggageField.create("user-id"), "baggage-user-id").build())
       .spanReporter(spans::add)
       .build();
   BraveTracer opentracing = BraveTracer.create(brave);

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveScopeManagerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveScopeManagerTest.java
@@ -15,8 +15,7 @@ package brave.opentracing;
 
 import brave.ScopedSpan;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import io.opentracing.Scope;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,9 +28,7 @@ public class OpenTracing0_33_BraveScopeManagerTest {
 
   List<zipkin2.Span> spans = new ArrayList<>();
   Tracing brave = Tracing.newBuilder()
-      .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-          .addScopeDecorator(StrictScopeDecorator.create())
-          .build())
+      .currentTraceContext(StrictCurrentTraceContext.create())
       .spanReporter(spans::add)
       .build();
   BraveTracer opentracing = BraveTracer.create(brave);

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import io.opentracing.SpanContext;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OpenTracing0_33_BraveSpanBuilderTest {
   Tracing tracing = Tracing.newBuilder().build();
@@ -34,7 +34,8 @@ public class OpenTracing0_33_BraveSpanBuilderTest {
     BraveSpanBuilder builder = newSpanBuilder().asChildOf((SpanContext) null);
 
     assertThat(builder)
-        .isEqualToComparingFieldByFieldRecursively(newSpanBuilder());
+        .usingRecursiveComparison()
+        .isEqualTo(newSpanBuilder());
   }
 
   /** Ensures when the caller invokes with null, nothing happens */
@@ -42,15 +43,16 @@ public class OpenTracing0_33_BraveSpanBuilderTest {
     BraveSpanBuilder builder = newSpanBuilder().asChildOf((Span) null);
 
     assertThat(builder)
-        .isEqualToComparingFieldByFieldRecursively(newSpanBuilder());
+        .usingRecursiveComparison()
+        .isEqualTo(newSpanBuilder());
   }
 
   /** Ensures when the caller invokes with null, nothing happens */
   @Test public void addReference_nullContext_noop() {
     BraveSpanBuilder builder = newSpanBuilder().addReference(References.CHILD_OF, null);
 
-    assertThat(builder)
-        .isEqualToComparingFieldByFieldRecursively(newSpanBuilder());
+    assertThat(builder).usingRecursiveComparison()
+        .isEqualTo(newSpanBuilder());
   }
 
   BraveSpanBuilder newSpanBuilder() {

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,10 +14,10 @@
 package brave.opentracing;
 
 import brave.Tracing;
+import brave.baggage.BaggageField;
+import brave.baggage.BaggagePropagation;
 import brave.propagation.B3Propagation;
-import brave.propagation.ExtraFieldPropagation;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.sampler.Sampler;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -57,10 +57,9 @@ public class OpenTracing0_33_BraveSpanTest {
     if (brave != null) brave.close();
     brave = tracingBuilder
         .localServiceName("tracer")
-        .currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-            .addScopeDecorator(StrictScopeDecorator.create())
-            .build())
-        .propagationFactory(ExtraFieldPropagation.newFactory(B3Propagation.FACTORY, "client-id"))
+        .currentTraceContext(StrictCurrentTraceContext.create())
+        .propagationFactory(BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
+            .addRemoteField(BaggageField.create("client-id")).build())
         .spanReporter(spans::add).build();
     tracer = BraveTracer.create(brave);
   }
@@ -369,5 +368,4 @@ public class OpenTracing0_33_BraveSpanTest {
     tracer.buildSpan("encode")
         .withTag(exceptionTag, new RuntimeException("ice cream"));
   }
-
 }


### PR DESCRIPTION
```java
// If you want to support baggage, create a field you would like to
// propagate and configure it with `BaggagePropagation`
COUNTRY_CODE = BaggageField.create("country-code");
// Baggage does not need to be sent remotely via headers, but if you configure
// with `addRemoteField()`, it will be
propagationFactory = BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY)
                                       .addRemoteField(COUNTRY_CODE)
                                       .build()

// Now, you can use natively or with OpenTracing
countryCode = span.getBaggageItem(COUNTRY_CODE.name()); // OpenTracing
countryCode = COUNTRY_CODE.get(); // Brave
countryCode = COUNTRY_CODE.get(span.unwrap().context()); // Brave
```

See https://github.com/openzipkin/brave/pull/1130