### PR TITLE
Extracts null on empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 language: java
 
-jdk: openjdk13
+jdk: openjdk14
 
 before_install:
   # allocate commits to CI, not the owner of the deploy key

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <brave.version>5.12.2</brave.version>
+    <brave.version>5.12.3</brave.version>
 
     <!-- default bytecode version for src/main -->
     <main.java.version>1.6</main.java.version>
@@ -43,7 +43,7 @@
 
     <!-- disable errorprone override warning as this allows us to support different versions -->
     <errorprone.args>-Xep:MissingOverride:OFF</errorprone.args>
-    <errorprone.version>2.3.4</errorprone.version>
+    <errorprone.version>2.4.0</errorprone.version>
 
     <!-- versions needed also for integration tests -->
     <junit.version>4.13</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,14)</version>
+                  <version>[1.8,15)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/src/main/java/brave/opentracing/BraveSpan.java
+++ b/src/main/java/brave/opentracing/BraveSpan.java
@@ -22,7 +22,6 @@ import io.opentracing.Span;
 import io.opentracing.tag.Tags;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * Holds the {@linkplain brave.Span} used by the underlying {@linkplain brave.Tracer}.
@@ -194,7 +193,7 @@ public final class BraveSpan implements Span {
     if (fields.isEmpty()) return "";
 
     StringBuilder result = new StringBuilder();
-    for (Iterator<? extends Entry<String, ?>> i = fields.entrySet().iterator(); i.hasNext(); ) {
+    for (Iterator<? extends Map.Entry<String, ?>> i = fields.entrySet().iterator(); i.hasNext(); ) {
       Map.Entry<String, ?> next = i.next();
       result.append(next.getKey()).append('=').append(next.getValue());
       if (i.hasNext()) result.append(' ');

--- a/src/main/java/brave/opentracing/OpenTracingVersion.java
+++ b/src/main/java/brave/opentracing/OpenTracingVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,6 +63,7 @@ abstract class OpenTracingVersion {
         return true;
       }
     } catch (NoSuchMethodException e) {
+      // EmptyCatch: ignored
     }
     return false;
   }
@@ -76,6 +77,7 @@ abstract class OpenTracingVersion {
           return new v0_32();
         }
       } catch (NoSuchMethodException e) {
+        // EmptyCatch: ignored
       }
       return null;
     }
@@ -103,6 +105,7 @@ abstract class OpenTracingVersion {
         Class.forName("io.opentracing.tag.Tag");
         return new v0_33();
       } catch (ClassNotFoundException e) {
+        // EmptyCatch: ignored
       }
       return null;
     }

--- a/src/main/java/brave/opentracing/v0_32_BraveScopeManager.java
+++ b/src/main/java/brave/opentracing/v0_32_BraveScopeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ final class v0_32_BraveScopeManager extends BraveScopeManager {
   //
   // When scopes are leaked this thread local will prevent this type from being unloaded. This can
   // cause problems in redeployment scenarios. https://github.com/openzipkin/brave/issues/785
+  @SuppressWarnings("ThreadLocalUsage")
   final ThreadLocal<Deque<v0_32_BraveScope>> currentScopes =
       new ThreadLocal<Deque<v0_32_BraveScope>>() {
         @Override protected Deque<v0_32_BraveScope> initialValue() {

--- a/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_32_BraveTracerTest.java
@@ -170,4 +170,24 @@ public class OpenTracing0_32_BraveTracerTest {
 
     openTracingSpan.unwrap().abandon();
   }
+
+  @Test public void extract_null_on_empty() {
+    Map<String, String> map = new LinkedHashMap<>();
+    TextMapAdapter request = new TextMapAdapter(map);
+
+    assertThat(opentracing.extract(Format.Builtin.HTTP_HEADERS, request)).isNull();
+  }
+
+  @Test public void extract_only_baggage() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put(countryCodeField.name(), "NO");
+    TextMapAdapter request = new TextMapAdapter(map);
+
+    BraveSpanContext partial = opentracing.extract(Format.Builtin.HTTP_HEADERS, request);
+    assertThat(partial).isNotNull();
+
+    BraveSpan span = opentracing.buildSpan("next").asChildOf(partial).start();
+    assertThat(span.getBaggageItem(countryCodeField.name())).isEqualTo("NO");
+    span.finish();
+  }
 }

--- a/src/test/java/brave/opentracing/OpenTracing0_33_BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/OpenTracing0_33_BraveTracerTest.java
@@ -420,4 +420,24 @@ public class OpenTracing0_33_BraveTracerTest {
 
     openTracingSpan.unwrap().abandon();
   }
+
+  @Test public void extract_null_on_empty() {
+    Map<String, String> map = new LinkedHashMap<>();
+    TextMapAdapter request = new TextMapAdapter(map);
+
+    assertThat(opentracing.extract(Format.Builtin.HTTP_HEADERS, request)).isNull();
+  }
+
+  @Test public void extract_only_baggage() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put(countryCodeField.name(), "NO");
+    TextMapAdapter request = new TextMapAdapter(map);
+
+    BraveSpanContext partial = opentracing.extract(Format.Builtin.HTTP_HEADERS, request);
+    assertThat(partial).isNotNull();
+
+    BraveSpan span = opentracing.buildSpan("next").asChildOf(partial).start();
+    assertThat(span.getBaggageItem(countryCodeField.name())).isEqualTo("NO");
+    span.finish();
+  }
 }


### PR DESCRIPTION
I noticed this https://github.com/opentracing-contrib/java-jms/pull/38
from @hanson76 and then thought probably we can just return null on
extract when there was nothing.

Side note about https://github.com/opentracing-contrib/java-jms/pull/38

However, the change above is a bit off as it ignores baggage. Iotw, lack
of traceId/spanId doesn't mean nothing was extracted, it just means a
trace context wasn't extracted. Ignoring extractions due to lack of trace
and span ID will drop baggage. In any case extracting only a trace ID is
valid in AWS.